### PR TITLE
fix: remove version constraints for arm64

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,9 +39,6 @@ Suggests:
     testthat
 VignetteBuilder: 
     knitr
-biocViews:
-Config/reticulate:list( packages = list( list(package =
-    "tensorflow", version = "2.0.0", pip = FALSE) ) )
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)

--- a/R/install.R
+++ b/R/install.R
@@ -8,7 +8,7 @@
 #'
 #' @param method Installation method ("conda" or "virtualenv").
 #'
-#' @param version TensorFlow version to install ( by default, "2.0.0").
+#' @param version TensorFlow version to install.
 #'
 #' @param extra_packages Additional PyPI packages to install along with TensorFlow.
 #'
@@ -37,7 +37,6 @@
 #' @export
 install_tensorflow <- function(method = c("conda", "virtualenv"),
                                conda = "auto",
-                               version = "2.0.0",
                                extra_packages = NULL,
                                ...) {
 
@@ -56,8 +55,8 @@ install_tensorflow <- function(method = c("conda", "virtualenv"),
   # Fix for h5py (see https://github.com/rstudio/keras/blob/67425c88109d308e983d631de9e5aa1369dcd913/R/install.R#L164)
   extra_packages <- c(
     extra_packages,
-    "h5py==2.10.0",
-    "pyyaml==3.12"
+    "h5py",
+    "pyyaml"
   )
 
   # Install TensorFlow on Linux and macOS
@@ -68,7 +67,6 @@ install_tensorflow <- function(method = c("conda", "virtualenv"),
         conda = conda,
         version = version,
         extra_packages = extra_packages,
-        conda_python_version = "3.6",
         pip_ignore_installed = FALSE,
         ...
       ),
@@ -97,7 +95,6 @@ install_tensorflow <- function(method = c("conda", "virtualenv"),
         envname = NULL,
         method = method,
         conda = conda,
-        python_version = "3.6",
         pip = TRUE,
         ...
       ),

--- a/vignettes/overview.Rmd
+++ b/vignettes/overview.Rmd
@@ -48,7 +48,7 @@ To install TensorFlow on your system, you need to run the following commands. **
 
 ```r
 library(deepredeff)
-install_tensorflow()
+tensorflow::install_tensorflow()
 ```
 This will provide you with an installation of Python and TensorFlow suitable for use with the `deepredeff` R package. In particular, this command will download and install Miniconda, and create the `r-reticulate` environment in the following locations:
 


### PR DESCRIPTION
Hi hi, 

Here are few changes so that deepredeff runs on the new Apple Silicon M1 (arm64). 
In short, python 3.6 is no longer supported on the new Apple machines ([here](https://bugs.python.org/msg382939)), and tensorflow 2.0.0 seems to need python 2.7 to 3.6 but not higher. Removing the constraints on the versions seems to work fine. 

Kind regards,
Clara

